### PR TITLE
Feature to support build analyzers report sync

### DIFF
--- a/app.py
+++ b/app.py
@@ -39,6 +39,7 @@ _INFRA_NAMESPACE = os.environ["THOTH_INFRA_NAMESPACE"]
 # Mapping from source job to destination job, boolean flag states if failed jobs should be synced as well.
 _CONFIG = {
     "adviser": (OpenShift.schedule_graph_sync_adviser, False),
+    "build-report": (OpenShift.schedule_graph_sync_build_report, False),
     "package-analyzer": (OpenShift.schedule_graph_sync_package_analyzer, False),
     "inspection": (OpenShift.schedule_graph_sync_inspection, True),
     "provenance-checker": (OpenShift.schedule_graph_sync_provenance_checker, False),


### PR DESCRIPTION
The handler would be called based upon the task defined in the openshift template of the build report job.
Depends-On: 
https://github.com/thoth-station/common/pull/654
https://github.com/thoth-station/build-analyzers/pull/140

Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>